### PR TITLE
More useful context in blunder timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] 2018-09-12
+### Changed
+- Added more context to timeout
+
 ## [1.0.3] 2018-04-02
 First public release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.0.4] 2018-09-12
-### Changed
+## [1.1.0] 2018-09-12
+### Added
 - Added more context to timeout
 
 ## [1.0.3] 2018-04-02

--- a/lib/blunder.ex
+++ b/lib/blunder.ex
@@ -166,7 +166,7 @@ defmodule Blunder do
     [details: "Blunder trapped exception", original_error: error, stacktrace: stacktrace]
   end
   defp wormhole_error_to_blunder_attrs({:timeout, timeout_ms}) do
-    [details: "funcation passed to trap_exceptions exceeded timeout of #{timeout_ms} ms"]
+    [details: "funcation passed to trap_exceptions exceeded timeout of #{timeout_ms} ms", stacktrace: Exception.format_stacktrace]
   end
   defp wormhole_error_to_blunder_attrs(error) do
     [details: "Blunder trapped exit", original_error: error]

--- a/lib/blunder.ex
+++ b/lib/blunder.ex
@@ -166,7 +166,7 @@ defmodule Blunder do
     [details: "Blunder trapped exception", original_error: error, stacktrace: stacktrace]
   end
   defp wormhole_error_to_blunder_attrs({:timeout, timeout_ms}) do
-    [details: "funcation passed to trap_exceptions exceeded timeout of #{timeout_ms} ms", stacktrace: Exception.format_stacktrace]
+    [details: "funcation passed to trap_exceptions exceeded timeout of #{timeout_ms} ms", stacktrace: Process.info(self(), :current_stacktrace) |> elem(1)]
   end
   defp wormhole_error_to_blunder_attrs(error) do
     [details: "Blunder trapped exit", original_error: error]

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Blunder.Mixfile do
     [
       app: :blunder,
       name: "Blunder",
-      version: "1.0.3",
+      version: "1.0.4",
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env),
       start_permanent: Mix.env == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Blunder.Mixfile do
     [
       app: :blunder,
       name: "Blunder",
-      version: "1.0.4",
+      version: "1.1.0",
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env),
       start_permanent: Mix.env == :prod,

--- a/test/blunder_test.exs
+++ b/test/blunder_test.exs
@@ -161,7 +161,7 @@ defmodule BlunderTest do
 
     test "when original_error is neither an exception nor a string" do
       assert Blunder.format(%Blunder{
-        original_error: {:a, :b, :c} 
+        original_error: {:a, :b, :c}
       }) =~ "{:a, :b, :c}"
     end
 


### PR DESCRIPTION
`Exception.format_stacktrace/1` without any attribute will call `Process.info(self(), :current_stacktrace)`

Example of stacktrace on the timeout test
```
{:error,
 %Blunder{
   code: :application_error,
   details: "funcation passed to trap_exceptions exceeded timeout of 0 ms",
   original_error: nil,
   severity: :error,
   stacktrace: "    (blunder) lib/blunder.ex:147: Blunder.trap_exceptions/2\n    test/blunder_test.exs:113: BlunderTest.\"test &trap_exceptions/2 handles timeouts\"/1\n    (ex_unit) lib/ex_unit/runner.ex:312: ExUnit.Runner.exec_test/1\n    (stdlib) timer.erl:166: :timer.tc/1\n    (ex_unit) lib/ex_unit/runner.ex:251: anonymous fn/4 in ExUnit.Runner.spawn_test/3\n",
   summary: "Application Error"
 }}
```